### PR TITLE
cleanup state machines

### DIFF
--- a/api/v1alpha1/statemachine_types.go
+++ b/api/v1alpha1/statemachine_types.go
@@ -257,6 +257,10 @@ type OrasConfig struct {
 	// +optional
 	Image string `json:"image,omitempty"`
 
+	// container image for the workflow manager (must be provided)
+	// +omitempty
+	NodeSelector string `json:"nodeSelector,omitempty"`
+
 	// Image pull policy (e.g., Always, Never, etc.)
 	// +kubebuilder:default="IfNotPresent"
 	// +default="IfNotPresent"

--- a/config/crd/bases/state-machine.converged-computing.org_statemachines.yaml
+++ b/config/crd/bases/state-machine.converged-computing.org_statemachines.yaml
@@ -207,6 +207,10 @@ spec:
                     default: registry
                     description: Name for the registry (defaults to registry)
                     type: string
+                  nodeSelector:
+                    description: container image for the workflow manager (must be
+                      provided)
+                    type: string
                   plainHttp:
                     description: Assume the registry doesn't use plain http
                     type: boolean

--- a/examples/dist/state-machine-operator-dev.yaml
+++ b/examples/dist/state-machine-operator-dev.yaml
@@ -215,6 +215,10 @@ spec:
                     default: registry
                     description: Name for the registry (defaults to registry)
                     type: string
+                  nodeSelector:
+                    description: container image for the workflow manager (must be
+                      provided)
+                    type: string
                   plainHttp:
                     description: Assume the registry doesn't use plain http
                     type: boolean

--- a/internal/controller/registry.go
+++ b/internal/controller/registry.go
@@ -92,6 +92,12 @@ func (r *StateMachineReconciler) createStatefulSet(
 			},
 		},
 	}
+
+	if spec.Spec.Registry.NodeSelector != "" {
+		nodeSelector := map[string]string{"node.kubernetes.io/instance-type": spec.Spec.Manager.NodeSelector}
+		statefulSet.Spec.Template.Spec.NodeSelector = nodeSelector
+	}
+
 	ctrl.SetControllerReference(spec, statefulSet, r.Scheme)
 	err := r.Create(ctx, statefulSet)
 	return statefulSet, err

--- a/python/state_machine_operator/manager/manager.py
+++ b/python/state_machine_operator/manager/manager.py
@@ -424,6 +424,9 @@ class WorkflowManager:
                 # Marking a job failed deletes all Kubernetes objects associated across stages.
                 # We do this because we assume no step should be retried, etc.
                 state_machine.mark_failed()
+                # If we get here, the job has already done retries for the step
+                # We need to cancel the state machine (all associated jobs)
+                state_machine.cleanup()
                 # Deleting the state machine means we stop tracking it
                 if job.jobid in self.trackers:
                     del self.trackers[job.jobid]


### PR DESCRIPTION
in the case of a failure, this indicates we have done all possible retries and we need to cleanup the jobs associated with the state machine. This also adds a node selector to the registry.