### PR TITLE
feat: node timings

### DIFF
--- a/api/v1alpha1/statemachine_types.go
+++ b/api/v1alpha1/statemachine_types.go
@@ -97,7 +97,7 @@ type JobStep struct {
 	// +default="amd64"
 	// +optional
 	Arch string `json:"arch,omitempty"`
-	
+
 	// Custom data config to provide to worker
 	// + optional
 	AppConfig string `json:"appConfig,omitempty"`

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,30 +26,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - rolebindings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - roles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - apps
   resources:
   - deployments
@@ -190,6 +166,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create
@@ -299,6 +283,30 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
   verbs:
   - create
   - delete

--- a/examples/dist/state-machine-operator-dev.yaml
+++ b/examples/dist/state-machine-operator-dev.yaml
@@ -343,30 +343,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - rolebindings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - roles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - apps
   resources:
   - deployments
@@ -507,6 +483,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create
@@ -616,6 +600,30 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
   verbs:
   - create
   - delete
@@ -838,8 +846,6 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      nodeSelector:
-        node.kubernetes.io/instance-type: m6a.4xlarge        
       containers:
       - args:
         - --metrics-bind-address=:8443

--- a/examples/dist/state-machine-operator-dev.yaml
+++ b/examples/dist/state-machine-operator-dev.yaml
@@ -846,6 +846,8 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      nodeSelector:
+        node.kubernetes.io/instance-type: m6a.4xlarge
       containers:
       - args:
         - --metrics-bind-address=:8443

--- a/examples/test/random-failure.yaml
+++ b/examples/test/random-failure.yaml
@@ -1,0 +1,36 @@
+apiVersion: state-machine.converged-computing.org/v1alpha1
+kind: StateMachine
+metadata:
+  name: state-machine
+spec:
+  manager:
+    pullPolicy: Never
+    interactive: true
+  workflow:
+    completed: 20
+  cluster:
+    maxSize: 2
+
+  jobs:
+  - name: job_a
+    config:
+      nodes: 1
+      coresPerTask: 1
+    image: rockylinux:9
+    script: |
+      sleep 5
+      selections=("yes" "no")
+      random_index=$((RANDOM % ${#selections[@]}))
+      choice="${selections[$random_index]}"
+      if [[ "$choice" == "yes" ]]; then
+         exit 1
+      fi
+
+  - name: job_b
+    config:
+      nodes: 1
+      coresPerTask: 1
+    image: rockylinux:9
+    script: |
+      sleep 5
+      exit 1

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -61,6 +61,7 @@ func NewStateMachineReconciler(
 // +kubebuilder:rbac:groups=state-machine.converged-computing.org,resources=statemachines/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=state-machine.converged-computing.org,resources=statemachines/finalizers,verbs=update
 
+//+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
@@ -86,8 +87,8 @@ func NewStateMachineReconciler(
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources="rolebindings",verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources="roles",verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources="rolebindings",verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources="roles",verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources="clusterrolebindings",verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources="clusterroles",verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete;exec
 //+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get;list;watch;create;update;patch;delete;exec
 //+kubebuilder:rbac:groups="",resources=jobs/status,verbs=get;list;watch;create;update;patch;delete;exec

--- a/python/state_machine_operator/tracker/__init__.py
+++ b/python/state_machine_operator/tracker/__init__.py
@@ -1,5 +1,7 @@
 import state_machine_operator.defaults as defaults
 
+from .watcher import Watcher
+
 
 def load(name):
     """

--- a/python/state_machine_operator/tracker/kubernetes/__init__.py
+++ b/python/state_machine_operator/tracker/kubernetes/__init__.py
@@ -1,3 +1,3 @@
-from .event import stream_events
+from .event import Watcher, stream_events
 from .state import get_namespace, list_jobs, list_jobs_by_status, queued_jobs, running_jobs
 from .tracker import KubernetesTracker as Tracker

--- a/python/state_machine_operator/tracker/kubernetes/event.py
+++ b/python/state_machine_operator/tracker/kubernetes/event.py
@@ -1,6 +1,10 @@
+import os
+import threading
 from logging import getLogger
 
 from kubernetes import client, config, watch
+
+import state_machine_operator.utils as utils
 
 from .job import Job, get_namespace
 
@@ -20,3 +24,88 @@ def stream_events():
     for event in w.stream(batch_v1.list_namespaced_job, namespace=get_namespace()):
         job = event["object"]
         yield Job(job)
+
+
+class Watcher:
+    """
+    Kubernetes watchers deliver pod and node events.
+    """
+
+    def __init__(self):
+        self.threads = {}
+        self.stop_event = threading.Event()
+        self.prepare_watchers()
+
+        # These should only be accessed by one thread each
+        # We want to capture pod pulling times and initial nodes (and changes) after that.
+        # Not doing pulling times for now.
+        self.nodes = {}
+        self.pods = {}
+
+    def results(self):
+        return {"nodes": self.nodes}
+
+    def save(self, outdir):
+        utils.write_json(self.nodes, os.path.join(outdir, "cluster-nodes.json"))
+
+    def prepare_watchers(self):
+        """
+        Prepare watchers for pods and nodes.
+        """
+        for function in ["watch_nodes"]:
+            thread = threading.Thread(target=getattr(self, function))
+            thread.daemon = True
+            self.threads[function] = thread
+
+    def start(self):
+        """
+        The pods thread looks for pulled pods in the namespace, and
+        the nodes thread starts with existing nodes, and then records
+        subsequent events.
+        """
+        for function, thread in self.threads.items():
+            LOGGER.debug(f"Starting thread watcher for {function}")
+            thread.start()
+
+    def stop(self):
+        """
+        We have a stop event, but in practice we don't wait for it to stop
+        """
+        self.stop_event.set()
+
+    def watch_pods(self):
+        """
+        We aren't watching pods for now, don't need metadata.
+        """
+        pass
+
+    def watch_nodes(self):
+        """
+        Collect list of nodes at experiment start, and then watch for changes.
+        """
+        api = client.CoreV1Api()
+
+        # Get starting state of the cluster - we care about ready nodes, timestamps
+        for node in api.list_node().items:
+            self.nodes[node.metadata.name] = {
+                "created": node.metadata.creation_timestamp.timestamp()
+            }
+
+        # For now, assume that nodes are added and removed.
+        # https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go
+        w = watch.Watch()
+        for event in w.stream(api.list_node):
+            node = event["object"]
+            if node.metadata.name not in self.nodes:
+                self.nodes[node.metadata.name] = {
+                    "created": node.metadata.creation_timestamp.timestamp()
+                }
+            if node.metadata.deletion_timestamp:
+                self.nodes[node.metadata.name][
+                    "deleted"
+                ] = node.metadata.deletion_timestamp.timestamp()
+
+            # Stop event
+            if self.stop_event.is_set():
+                w.stop()
+                return

--- a/python/state_machine_operator/tracker/kubernetes/event.py
+++ b/python/state_machine_operator/tracker/kubernetes/event.py
@@ -1,3 +1,4 @@
+import json
 import os
 import threading
 from logging import getLogger
@@ -46,6 +47,7 @@ class Watcher:
         return {"nodes": self.nodes}
 
     def save(self, outdir):
+        print("=== nodes\n" + json.dumps(self.nodes) + "\n===")
         utils.write_json(self.nodes, os.path.join(outdir, "cluster-nodes.json"))
 
     def prepare_watchers(self):
@@ -88,7 +90,8 @@ class Watcher:
         # Get starting state of the cluster - we care about ready nodes, timestamps
         for node in api.list_node().items:
             self.nodes[node.metadata.name] = {
-                "created": node.metadata.creation_timestamp.timestamp()
+                "created": node.metadata.creation_timestamp.timestamp(),
+                "labels": node.metadata.labels,
             }
 
         # For now, assume that nodes are added and removed.

--- a/python/state_machine_operator/tracker/watcher.py
+++ b/python/state_machine_operator/tracker/watcher.py
@@ -1,0 +1,18 @@
+class Watcher:
+    """
+    Watcher base (abstract class) that provides useless functions.
+    This is only if a tracker doesn't have a watcher class, it can
+    expose the same (empty) interface.
+    """
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def save(self, outdir):
+        pass
+
+    def results(self, outdir):
+        pass


### PR DESCRIPTION
We need to make it easy to see when nodes go up and down in the context of an experiment. This gives a cluster view of nodes, and that permission might be too big (and also assumes that the user can filter down to those used in the workflow) but for our experiments, we need to have these timestamps coupled directly with the workflow. We should be able to easily see the node creations / deletions that are in the same span as when a workflow is running. I am doing this by introducing the idea of custom tracker watchers, which are started, stopped, and then asked to save any data to some path. We do this design because Flux will not have these features.

This is a simple example testing with kind - no autoscaling.

![image](https://github.com/user-attachments/assets/5e6f5fd0-1247-40bb-9cd0-490f3f1f3b63)

I'm hoping it can be as simple as getting the node timestamps. and this assumes an event will come in that has them. I'll test this on an autoscaling cluster (that has nodes removed) tomorrow.  I really want this data to be solid, and I'm not happy now with getting timestamps from two places that are largely unlinked.