### PR TITLE
bug: flux misses events

### DIFF
--- a/python/state_machine_operator/tracker/flux/event.py
+++ b/python/state_machine_operator/tracker/flux/event.py
@@ -19,10 +19,10 @@ skip_events = [
     "alloc",
     "release",
     "free",
-    "clean",
+    "finish",
 ]
 
-# Mostly interested in final and start
+# We use start and clean, as start is when the job actually starts, but clean is the last job event.
 
 
 def stream_events():

--- a/python/state_machine_operator/tracker/flux/job.py
+++ b/python/state_machine_operator/tracker/flux/job.py
@@ -35,16 +35,12 @@ class FluxJob(BaseJob):
         self.jobspec = jobspec
         self.fluxid = jobid
 
+        # Get the state at time of completion
+        self.state = flux.job.get_job(handle, self.fluxid)
+
     @property
     def label(self):
         return f"{self.jobid}_{self.step_name}"
-
-    @property
-    def state(self):
-        """
-        State must always be retrieved dynamically
-        """
-        return flux.job.get_job(handle, self.fluxid)
 
     @property
     def jobid(self):

--- a/python/state_machine_operator/tracker/flux/job.py
+++ b/python/state_machine_operator/tracker/flux/job.py
@@ -35,9 +35,6 @@ class FluxJob(BaseJob):
         self.jobspec = jobspec
         self.fluxid = jobid
 
-        # Get the state at time of completion
-        self.state = flux.job.get_job(handle, self.fluxid)
-
     @property
     def label(self):
         return f"{self.jobid}_{self.step_name}"
@@ -55,6 +52,13 @@ class FluxJob(BaseJob):
     @property
     def step_name(self):
         return self.jobspec["attributes"]["user"].get("app")
+
+    @property
+    def state(self):
+        """
+        State must always be retrieved dynamically
+        """
+        return flux.job.get_job(handle, self.fluxid)
 
     def is_active(self):
         """

--- a/python/state_machine_operator/tracker/flux/job.py
+++ b/python/state_machine_operator/tracker/flux/job.py
@@ -70,7 +70,7 @@ class FluxJob(BaseJob):
         """
         Determine if a job is completed
         """
-        return self.state["status"] == "COMPLETED"
+        return self.state["status"] in ["COMPLETED", "FAILED"]
 
     def is_failed(self):
         """

--- a/python/state_machine_operator/tracker/flux/state.py
+++ b/python/state_machine_operator/tracker/flux/state.py
@@ -56,6 +56,9 @@ def list_jobs(*args, **kwargs):
 def queued_jobs(namespace=None):
     """
     A queued job is not active and doesn't have a completion time.
+
+    We haven't used this yet so it should throw up if we do
+    (and then we will write it :)
     """
     print("flux queued jobs")
     import IPython
@@ -119,17 +122,17 @@ def list_jobs_by_status(label_name="app", label_value=None):
     # These are the lists we will populate.
     states = {"success": [], "failed": [], "running": [], "queued": [], "unknown": []}
     for job in jobs:
-        if job["result"] == "COMPLETED" and job["success"]:
+        if job["status"] == "COMPLETED":
             states["success"].append(Job(job))
             continue
 
         # Failure means we finished with failed condition
-        if job["result"] == "COMPLETED" and not job["success"]:
-            states["failed"].append(job)
+        if job["status"] == "FAILED":
+            states["failed"].append(Job(job))
             continue
 
-        # Pending
-        if job["state"] == "SCHED":
+        # Pending or queued
+        if job["state"] in ["NEW", "DEPEND", "PRIORITY", "SCHED"]:
             states["queued"].append(Job(job))
             continue
 


### PR DESCRIPTION
Since we dynamically retrieve state for a flux job, this is problematic if there is a race between when an event is emit and when we (again) try to get state. I am not sure how to deal with this, but I am going to try moving the saving of the state to when the job is generated, which hopefully is closer than when it is checked incrementally later