### PR TITLE
feat: save kubernetes logs.

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -102,6 +102,19 @@ rules:
   - update
   - watch
 - apiGroups:
+  - batch
+  resources:
+  - pods/log
+  verbs:
+  - create
+  - delete
+  - exec
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - ""

--- a/examples/dist/state-machine-operator-dev.yaml
+++ b/examples/dist/state-machine-operator-dev.yaml
@@ -419,6 +419,19 @@ rules:
   - update
   - watch
 - apiGroups:
+  - batch
+  resources:
+  - pods/log
+  verbs:
+  - create
+  - delete
+  - exec
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - ""
@@ -846,8 +859,6 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      nodeSelector:
-        node.kubernetes.io/instance-type: c7a.4xlarge
       containers:
       - args:
         - --metrics-bind-address=:8443

--- a/examples/test/save-logs.yaml
+++ b/examples/test/save-logs.yaml
@@ -1,0 +1,40 @@
+apiVersion: state-machine.converged-computing.org/v1alpha1
+kind: StateMachine
+metadata:
+  name: state-machine
+spec:
+  manager:
+    pullPolicy: Never
+    
+  workflow:
+    completed: 2
+  cluster:
+    maxSize: 2
+
+  jobs:
+  - name: job_a
+    properties:
+      save-path: "/opt"
+    config:
+      nodes: 1
+      coresPerTask: 1
+    image: rockylinux:9
+    script: echo This is the first
+    
+  - name: job_b
+    properties:
+      save-path: "/opt"
+    config:
+      nodes: 1
+      coresPerTask: 1
+    image: rockylinux:9
+    script: echo This is the second
+    
+  - name: job_c
+    config:
+      nodes: 1
+      coresPerTask: 1
+    properties:
+      save-path: "/opt"
+    image: rockylinux:9
+    script: echo This is the third

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -93,7 +93,8 @@ func NewStateMachineReconciler(
 //+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get;list;watch;create;update;patch;delete;exec
 //+kubebuilder:rbac:groups="",resources=jobs/status,verbs=get;list;watch;create;update;patch;delete;exec
 //+kubebuilder:rbac:groups=batch,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;exec
-//+kubebuilder:rbac:groups=batch,resources=pods,verbs=get;list;watch;create;update;patch;delete;exec
+//+kubebuilder:rbac:groups=batch,resources=pods,verbs=get;list;watch;create;update;patch;delete;exec;
+//+kubebuilder:rbac:groups=batch,resources=pods/log,verbs=get;list;watch;create;update;patch;delete;exec;
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/rbac.go
+++ b/internal/controller/rbac.go
@@ -112,7 +112,7 @@ func (r *StateMachineReconciler) createRole(
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"", "batch"},
-				Resources: []string{"pods", "jobs", "configmaps", "jobs/status"},
+				Resources: []string{"pods", "pods/log", "jobs", "configmaps", "jobs/status"},
 				Verbs:     []string{"list", "get", "patch", "create", "delete", "watch"},
 			},
 		},

--- a/python/state_machine_operator/machine/machine.py
+++ b/python/state_machine_operator/machine/machine.py
@@ -91,18 +91,22 @@ def is_succeeded(self, state_name=None):
     return getattr(self, f"{state_name}_success", False) is True
 
 
-def mark_succeeded(self, state_name=None):
+def mark_succeeded(self, job=None, state_name=None):
     """
     Mark the current state succeeded (default) or another specific state.
     """
+    tracker = self.trackers[self.current_state.id]
+    tracker.save_log(job)
     state_name = state_name or self.current_state.id
     setattr(self, f"{state_name}_success", True)
 
 
-def mark_failed(self, state_name=None):
+def mark_failed(self, job=None, state_name=None):
     """
     Mark the current state failed (default) or another specific state.
     """
+    tracker = self.trackers[self.current_state.id]
+    tracker.save_log(job)
     state_name = state_name or self.current_state.id
     setattr(self, f"{state_name}_failure", True)
 
@@ -121,7 +125,7 @@ def mark_running(self, running_state):
             return
         # If we get here, we have not hit the running state
         # We assume we completed previous states with success
-        self.mark_succeeded(state)
+        self.mark_succeeded(state_name=state)
 
 
 def on_change(self):

--- a/python/state_machine_operator/manager/manager.py
+++ b/python/state_machine_operator/manager/manager.py
@@ -394,7 +394,7 @@ class WorkflowManager:
         """
         self.add_timestamp(f"{job.label}_succeeded")
         LOGGER.debug(f"Job {job.jobid} completed stage '{state_machine.current_state.id}'")
-        state_machine.mark_succeeded()
+        state_machine.mark_succeeded(job)
         # Only change if we aren't complete
         if state_machine.current_state.id != "complete":
             state_machine.change()
@@ -448,7 +448,7 @@ class WorkflowManager:
                 LOGGER.debug(f"Job {job.jobid} failed stage '{state_machine.current_state.id}'")
                 # Marking a job failed deletes all Kubernetes objects associated across stages.
                 # We do this because we assume no step should be retried, etc.
-                state_machine.mark_failed()
+                state_machine.mark_failed(job)
                 # If we get here, the job has already done retries for the step
                 # We need to cancel the state machine (all associated jobs)
                 state_machine.cleanup()

--- a/python/state_machine_operator/tracker/tracker.py
+++ b/python/state_machine_operator/tracker/tracker.py
@@ -125,6 +125,16 @@ class BaseTracker:
         return self.job_desc["name"]
 
     @property
+    def save_path(self):
+        return (self.properties or {}).get("save-path")
+
+    def save_log(self, job=None):
+        """
+        Save a log for a job to a user-specified location.
+        """
+        pass
+
+    @property
     def properties(self):
         """
         Properties are attributes that are specific to a tracker.


### PR DESCRIPTION
We have been saving artifacts for everything, relying on the application to take the burden of saving its own logging retrieved from the registry. For experiments with gpu selection we just need one little value, and I think it would be easier to save all the logs instead of using oras. This feature supports that, where the user adds a properties -> save-path, and under that path "logs" is created that is named by the job, step, and pod index.