### PR TITLE
feat: allow multiple node jobs

### DIFF
--- a/examples/test/multiple-pods.yaml
+++ b/examples/test/multiple-pods.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   manager:
     pullPolicy: Never
-
+    interactive: true
   workflow:
     completed: 2
   cluster:
@@ -25,7 +25,7 @@ spec:
     properties:
       save-path: "/opt"
     config:
-      nodes: 1
+      nodes: 4
       coresPerTask: 1
     image: rockylinux:9
     script: echo This is the second

--- a/python/state_machine_operator/manager/__init__.py
+++ b/python/state_machine_operator/manager/__init__.py
@@ -61,6 +61,12 @@ def get_parser():
         help="Directory with configuration files.",
     )
     start.add_argument(
+        "--quiet",
+        help="Don't print progress",
+        default=False,
+        action="store_true",
+    )
+    start.add_argument(
         "--plain-http",
         help="Use plain http for the registry.",
         default=False,
@@ -108,6 +114,7 @@ def main():
         # Will overwrite what is set in config
         workdir=args.workdir,
         plain_http=args.plain_http,
+        quiet=args.quiet,
     )
     manager.start()
 

--- a/python/state_machine_operator/tracker/kubernetes/job.py
+++ b/python/state_machine_operator/tracker/kubernetes/job.py
@@ -40,15 +40,16 @@ class Job(BaseJob):
 
     def is_failed(self):
         """
-        Determine if a job is failed
+        Determine if a job is failed.
         """
-        return self.job.status.failed == 1
+        return not self.is_succeeded()
 
     def is_succeeded(self):
         """
         Determine if a job has succeeded
+        We need to have a completion time and no failed indices.
         """
-        return self.job.status.succeeded == 1
+        return self.is_completed and not self.job.status.failed
 
 
 def get_namespace():

--- a/python/state_machine_operator/tracker/kubernetes/state.py
+++ b/python/state_machine_operator/tracker/kubernetes/state.py
@@ -58,23 +58,33 @@ def list_jobs_by_status(label_name="app", label_value=None):
     states = {"success": [], "failed": [], "running": [], "queued": [], "unknown": []}
 
     for job in jobs:
+
+        # These are *counts* of job indices, not boolean 0/1
+        succeeded = job.status.succeeded
+        failed = job.status.failed
+        active = job.status.active
+        not_active = active in [0, None]
+
+        # This is a completion time for the job
+        completion_time = job.status.completion_time
+
         # Success means we finished with succeeded condition
-        if job.status.succeeded == 1 and job.status.completion_time is not None:
+        if succeeded is not None and succeeded > 0 and completion_time is not None:
             states["success"].append(Job(job))
             continue
 
         # Failure means we finished with failed condition
-        if job.status.failed == 1:
+        if failed is not None and failed > 0:
             states["failed"].append(Job(job))
             continue
 
         # Not active, and not finished is queued
-        if not job.status.active and not job.status.completion_time:
+        if not_active and not completion_time:
             states["queued"].append(Job(job))
             continue
 
         # Active, and not finished is running
-        if job.status.active == 1 and not job.status.completion_time:
+        if active and not completion_time:
             states["running"].append(Job(job))
             continue
 

--- a/python/state_machine_operator/tracker/kubernetes/tracker.py
+++ b/python/state_machine_operator/tracker/kubernetes/tracker.py
@@ -349,6 +349,7 @@ class KubernetesTracker(BaseTracker):
 
         # We might have one pod, but can't assume
         for i, pod in enumerate(pods):
+            print(f"Saving log for {pod.metadata.name}")
             try:
                 logs = api.read_namespaced_pod_log(
                     name=pod.metadata.name,
@@ -363,7 +364,10 @@ class KubernetesTracker(BaseTracker):
                 )
                 # Don't write twice
                 if not os.path.exists(log_file):
+                    print(f"Saving log file {log_file}")
                     utils.write_file(logs, log_file)
+                else:
+                    print(f"Log file {log_file} already exists")
 
             except client.exceptions.ApiException as e:
                 print(f"Error getting logs: {e}")


### PR DESCRIPTION
There is a bug in the kubernetes tracker that we treat the failed/succeeded as boolean (0/1) when it is actually a count of indices. We have not done experiments with >1 nodes so this has not been an issue (or caught). This change will fix it.